### PR TITLE
Fixed Mistake with AdvancederDrive

### DIFF
--- a/src/main/java/frc/robot/commands/AutonomousTools/AdvancederDrive.java
+++ b/src/main/java/frc/robot/commands/AutonomousTools/AdvancederDrive.java
@@ -90,7 +90,7 @@ public class AdvancederDrive extends Command {
 		currentRight = Robot.drivetrain.rightEncoder;
 		
 		/* Sets the motor with their respective offsets based on heading adjustment */ 
-		Robot.drivetrain.tank(distance * encoderCheck() * lidarCheck() * gyroCheck("left"), direction * encoderCheck() * lidarCheck() * gyroCheck("right"));
+		Robot.drivetrain.tank(direction * encoderCheck() * lidarCheck() * gyroCheck("left"), direction * encoderCheck() * lidarCheck() * gyroCheck("right"));
 	}
 	
 	/** Uses encoders to check whether or not to start slowing down */


### PR DESCRIPTION
There was a mistake where `Robot.drivetrain.tank` is called, where on one side the value is multiplied by `direction` and on the other side by `distance`. I fixed it, so both sides multiply by `direction`.