### PR TITLE
Rearrangement of RobotMap objects, and got rid of old versions of hatch motors

### DIFF
--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -30,38 +30,43 @@ public class RobotMap {
 	public static WPI_VictorSPX leftSlave;
 	public static WPI_VictorSPX leftSlaveTwo;
 
+	public static WPI_VictorSPX leftClimber;
 	public static WPI_TalonSRX rightClimber;
+
 	public static WPI_TalonSRX lidar;
+
 	public static WPI_TalonSRX hatchCollect;
 	public static WPI_TalonSRX hatchLift;
-	public static WPI_TalonSRX cargoLift;
+
 	public static WPI_TalonSRX cargoCollect;
-	
-	public static WPI_VictorSPX leftClimber;
+	public static WPI_TalonSRX cargoLift;
 	public static WPI_VictorSPX cargoLiftTwo;
+	
 
 	public static Solenoid high;
 	public static Solenoid low;
+
 	public static BuiltInAccelerometer accelerometer;
+
 	public static Solenoid finger;
 	public static Solenoid hatchExtender;
-	public static WPI_TalonSRX hatchIntake;
-	public static WPI_TalonSRX hatchFlipper;
+
 	public static DigitalInput flipperLimitSwitchUp;
 	public static DigitalInput flipperLimitSwitchDown;
-  	public static void init() {
+
+	public static void init() {
+
+		leftMaster = new WPI_TalonSRX(8);
+		leftSlave = new WPI_VictorSPX(9);
+		leftSlaveTwo = new WPI_VictorSPX(7);
+
+		rightMaster = new WPI_TalonSRX(4);
+		rightSlave = new WPI_VictorSPX(2);
+		rightSlaveTwo = new WPI_VictorSPX(3);
+
 		headingGyro = new ADXRS450_Gyro();
 		accelerometer = new BuiltInAccelerometer();
 
-		rightSlaveTwo = new WPI_VictorSPX(3);
-		rightSlave = new WPI_VictorSPX(2);
-		rightMaster = new WPI_TalonSRX(4);
-		leftSlaveTwo = new WPI_VictorSPX(7);
-		leftSlave = new WPI_VictorSPX(9);
-		leftMaster = new WPI_TalonSRX(8);
-
-		hatchFlipper=new WPI_TalonSRX(7);
-		hatchIntake=new WPI_TalonSRX(5);
 		lidar = new WPI_TalonSRX(15);
 
 		hatchCollect = new WPI_TalonSRX(5);
@@ -70,9 +75,9 @@ public class RobotMap {
 		rightClimber = new WPI_TalonSRX(10);
 		leftClimber = new WPI_VictorSPX(11);
 
-		cargoLiftTwo = new WPI_VictorSPX(12);
-		cargoLift = new WPI_TalonSRX(13);
 		cargoCollect = new WPI_TalonSRX(14);
+		cargoLift = new WPI_TalonSRX(13);
+		cargoLiftTwo = new WPI_VictorSPX(12);
 
 		high = new Solenoid (1, 7);
 		low = new Solenoid (1, 5);


### PR DESCRIPTION

The motors weren't arranged or grouped by function, so I changed that. There were two copies of the hatch lift and collector motors, one from my version and one from the working version. I got rid of the motors from my version, since the new Hatch subsystem doesn't use them, and as they use the same CAN IDs that could really cause some unpleasant problems.

Much of the changes are for readability, but the part with the old versions of the hatch motors could actually cause major problems, so please look at the changes.