### PR TITLE
Fixed package names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2019.1.1"
+    id "edu.wpi.first.GradleRIO" version "2019.4.1"
 }
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -2,7 +2,7 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.buttons.JoystickButton;
 import frc.robot.commands.*;
-import frc.robot.commands.hatchCommands.*;
+import frc.robot.commands.HatchCommands.*;
 
 /**
  * This class is the glue that binds the controls on the physical operator

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -13,7 +13,7 @@ import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.commands.SystemTest;
-import frc.robot.commands.autonomousTools.AutoTest;
+import frc.robot.commands.AutonomousTools.AutoTest;
 import frc.robot.subsystems.*;
 
 /**

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -88,6 +88,8 @@ public class RobotMap {
 		hatchRetractor = new Solenoid(4);
 		finger = new Solenoid(0);
 
+		collectorInSensor = new DigitalInput(1/*Wherever*/);
+		duckInSensor = new DigitalInput(2/*Wherever*/);
 		/**HERE'S WHERE THE LIMIT SWITCHES WILL GO
 		hatchFlipLimitSwitchUp = new DigitalInput(WHATEVER THE ID IS);
 		hatchFlipLimitSwitchDown = new DigitalInput(WHATEVER THE ID IS);

--- a/src/main/java/frc/robot/commands/Autonomous/AutoStartCargo.java
+++ b/src/main/java/frc/robot/commands/Autonomous/AutoStartCargo.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.autonomous;
+package frc.robot.commands.Autonomous;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 

--- a/src/main/java/frc/robot/commands/Autonomous/AutoStartRocket.java
+++ b/src/main/java/frc/robot/commands/Autonomous/AutoStartRocket.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.autonomous;
+package frc.robot.commands.Autonomous;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 

--- a/src/main/java/frc/robot/commands/Autonomous/AutoStepCargo.java
+++ b/src/main/java/frc/robot/commands/Autonomous/AutoStepCargo.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.autonomous;
+package frc.robot.commands.Autonomous;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 

--- a/src/main/java/frc/robot/commands/Autonomous/AutoStepRocket.java
+++ b/src/main/java/frc/robot/commands/Autonomous/AutoStepRocket.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.autonomous;
+package frc.robot.commands.Autonomous;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 

--- a/src/main/java/frc/robot/commands/AutonomousTools/AdvancedTurn.java
+++ b/src/main/java/frc/robot/commands/AutonomousTools/AdvancedTurn.java
@@ -1,4 +1,4 @@
-package frc.robot.commands.autonomousTools;
+package frc.robot.commands.AutonomousTools;
 
 import frc.robot.*;
 import edu.wpi.first.wpilibj.command.Command;

--- a/src/main/java/frc/robot/commands/AutonomousTools/AdvancederDrive.java
+++ b/src/main/java/frc/robot/commands/AutonomousTools/AdvancederDrive.java
@@ -1,4 +1,4 @@
-package frc.robot.commands.autonomousTools;
+package frc.robot.commands.AutonomousTools;
 
 import frc.robot.*;
 import edu.wpi.first.wpilibj.command.Command;

--- a/src/main/java/frc/robot/commands/AutonomousTools/AutoTest.java
+++ b/src/main/java/frc/robot/commands/AutonomousTools/AutoTest.java
@@ -1,4 +1,4 @@
-package frc.robot.commands.autonomousTools;
+package frc.robot.commands.AutonomousTools;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 

--- a/src/main/java/frc/robot/commands/AutonomousTools/VisionerCuberTrackerer.java
+++ b/src/main/java/frc/robot/commands/AutonomousTools/VisionerCuberTrackerer.java
@@ -1,4 +1,4 @@
-package frc.robot.commands.autonomousTools;
+package frc.robot.commands.AutonomousTools;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import edu.wpi.first.wpilibj.command.Command;

--- a/src/main/java/frc/robot/commands/HatchCommands/FingerLower.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/FingerLower.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/HatchCommands/FingerRaise.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/FingerRaise.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/HatchCommands/FlipDown.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/FlipDown.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/HatchCommands/FlipUp.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/FlipUp.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/HatchCommands/HatchExtend.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/HatchExtend.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/HatchCommands/HatchPlace.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/HatchPlace.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 import edu.wpi.first.wpilibj.command.WaitCommand;

--- a/src/main/java/frc/robot/commands/HatchCommands/HatchRetract.java
+++ b/src/main/java/frc/robot/commands/HatchCommands/HatchRetract.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/HatchControls.java
+++ b/src/main/java/frc/robot/commands/HatchControls.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.HatchCommands;
+package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/hatchCommands/HatchControls.java
+++ b/src/main/java/frc/robot/commands/hatchCommands/HatchControls.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.Command;
 import frc.robot.Robot;

--- a/src/main/java/frc/robot/commands/hatchCommands/HatchGrab.java
+++ b/src/main/java/frc/robot/commands/hatchCommands/HatchGrab.java
@@ -5,7 +5,7 @@
 /* the project.                                                               */
 /*----------------------------------------------------------------------------*/
 
-package frc.robot.commands.hatchCommands;
+package frc.robot.commands.HatchCommands;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
 import edu.wpi.first.wpilibj.command.WaitCommand;

--- a/src/main/java/frc/robot/subsystems/Hatch.java
+++ b/src/main/java/frc/robot/subsystems/Hatch.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 import frc.robot.Presets;
 import frc.robot.Robot;
 import frc.robot.RobotMap;
-import frc.robot.commands.hatchCommands.*;
+import frc.robot.commands.HatchCommands.*;
 
 public class Hatch extends Subsystem {
   

--- a/src/main/java/frc/robot/subsystems/Hatch.java
+++ b/src/main/java/frc/robot/subsystems/Hatch.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 import frc.robot.Presets;
 import frc.robot.Robot;
 import frc.robot.RobotMap;
-import frc.robot.commands.HatchCommands.*;
+import frc.robot.commands.HatchControls;
 
 public class Hatch extends Subsystem {
   
@@ -20,13 +20,16 @@ public class Hatch extends Subsystem {
 	public final DigitalInput limitUp = RobotMap.hatchFlipLimitSwitchUp;
 	public final DigitalInput limitDown = RobotMap.hatchFlipLimitSwitchDown;
 
-	public final DigitalInput collectIn = RobotMap.collectorInSensor;
-	public final DigitalInput duckIn = RobotMap.duckInSensor;
+	public final DigitalInput collectInSensor = RobotMap.collectorInSensor;
+	public final DigitalInput duckInSensor = RobotMap.duckInSensor;
 
 	private double lift;
 	private double collect;
-	private final double DIST=100;
+	private final double ANGLE_UP=0;
+	private final double ANGLE_CENTER=100;
+	private final double ANGLE_DOWN=200;
 	public final double collectorPower=0.5;
+	private double collectorValue=0;
 	private double P = .7;
 	private double I = 0.004;
 	private double D = 0;
@@ -40,7 +43,7 @@ public class Hatch extends Subsystem {
 		hatchLift.configFactoryDefault();
 		hatchCollect.configFactoryDefault();
 
-  	hatchLift.setSafetyEnabled(false);
+  		hatchLift.setSafetyEnabled(false);
 		hatchCollect.setSafetyEnabled(false);
 		/* Set Neutral Mode */
 		hatchLift.setNeutralMode(NeutralMode.Brake);
@@ -93,6 +96,15 @@ public class Hatch extends Subsystem {
   public void periodic() {
 		lift = hatchLift.getSelectedSensorPosition();
 		collect = hatchCollect.getSelectedSensorPosition();
+		boolean collectorIn=collectInSensor.get();
+		if(collectorIn){
+			collectorValue=Math.max(0,collectorValue);
+		}
+		if(collectorValue==0){
+			setCollectorBase(collectorValue);
+		}else{
+			collectorZero();
+		}
 		// boolean[] state = getLimitSwitchState();
 		// double velocity = hatchLift.getSelectedSensorVelocity();
 		/*if (Robot.networktable.table.getEntry("changeP").getDouble(P) != P ||
@@ -112,8 +124,12 @@ public class Hatch extends Subsystem {
 		hatchLift.set(ControlMode.Position, value);
 	}
 
-	public void setCollector(double value) {
+	public void setCollectorBase(double value) {
 		hatchCollect.set(ControlMode.PercentOutput, value);
+	}
+
+	public void setCollector(double value){
+		collectorValue=value;
 	}
 
 	public void setCollectorPosition(double value) {
@@ -137,15 +153,15 @@ public class Hatch extends Subsystem {
 	}
 	
 	public void setFlipperUp() {
-		setFlipper(0);
+		setFlipperPosition(ANGLE_UP);
 	}
 
 	public void setFlipperCenter() {
-		setFlipper(DIST);
+		setFlipperPosition(ANGLE_CENTER);
 	}
 
 	public void setFlipperDown() {
-		setFlipper(DIST * 2);
+		setFlipperPosition(ANGLE_DOWN);
 	}
 
 	public void fingerLower() {

--- a/src/main/java/frc/robot/subsystems/Hatch.java
+++ b/src/main/java/frc/robot/subsystems/Hatch.java
@@ -1,5 +1,7 @@
 package frc.robot.subsystems;
 
+import java.util.Set;
+
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
@@ -97,12 +99,25 @@ public class Hatch extends Subsystem {
 		lift = hatchLift.getSelectedSensorPosition();
 		collect = hatchCollect.getSelectedSensorPosition();
 		boolean collectorIn=collectInSensor.get();
-		if(collectorIn){
+		boolean duckIn=duckInSensor.get();
+		Robot.networktable.table.getEntry("CollectorInSensorRaw").setBoolean(collectorIn);
+		Robot.networktable.table.getEntry("DuckInSensorRaw").setBoolean(duckIn);
+		if(collectorIn) {
+			Robot.networktable.table.getEntry("CollectorInSensor").setString("Hatch Collector: Loaded!");
+		} else {
+			Robot.networktable.table.getEntry("CollectorInSensor").setString("Hatch Collector: Empty!");
+		}
+		if(duckIn) {
+			Robot.networktable.table.getEntry("DuckInSensor").setString("Duck: Loaded!");
+		} else {
+			Robot.networktable.table.getEntry("DuckInSensor").setString("Duck: Empty!");
+		}
+		if(collectorIn) {
 			collectorValue=Math.max(0,collectorValue);
 		}
-		if(collectorValue==0){
+		if(collectorValue==0) {
 			setCollectorBase(collectorValue);
-		}else{
+		} else {
 			collectorZero();
 		}
 		// boolean[] state = getLimitSwitchState();
@@ -128,7 +143,7 @@ public class Hatch extends Subsystem {
 		hatchCollect.set(ControlMode.PercentOutput, value);
 	}
 
-	public void setCollector(double value){
+	public void setCollector(double value) {
 		collectorValue=value;
 	}
 


### PR DESCRIPTION
I know that lowerCamelCase is the way we're *supposed* to do things, but it's not the way we *are* doing things, and if I change the folders I get some really bad conflicts, so I'm changing the package names back to what they were. In any case, the folders weren't renamed, so there was an error in every file I had to change, and now there isn't.

Seriously, in VSCode every file in AutonomousTools, Autonomous, and HatchCommands is all red. It needs fixing.