### PR TITLE
Fixed Bling NetworkTables problems.

### DIFF
--- a/src/main/java/frc/robot/Bling.java
+++ b/src/main/java/frc/robot/Bling.java
@@ -15,9 +15,6 @@ package frc.robot;
  import edu.wpi.first.networktables.NetworkTable;
 
  public class Bling {
-        NetworkTable newtable;
-
-
         private String color;
         private String speed;
         private int min;
@@ -43,7 +40,7 @@ package frc.robot;
         }
         
         public void send() {
-                newtable.getEntry("Bling_Command").setString(put);
+                Robot.networktable.table.getEntry("Bling_Command").setString(put);
         }
 
         public void setPattern( BlingMode pattern ) {


### PR DESCRIPTION
NetworkTables works differently this year, so the old bling code Nick based his code no longer works. If the code is ever run in its current state, the robot encounters a NullPointerException and disables.